### PR TITLE
electronの場合はページ移動をさせる

### DIFF
--- a/bin/watch.js
+++ b/bin/watch.js
@@ -12,6 +12,8 @@ const {
 } = require('./lib/util')
 const { PATTERN_HTML, MOCK_HTML } = require('./lib/const')
 
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 module.exports = async argv => {
   rimraf.sync(argv.outDir)
   await buildMocktimesFiles(argv)
@@ -19,7 +21,10 @@ module.exports = async argv => {
   if (!argv.onlyPattern) {
     chokidar
       .watch(getUserFiles(argv).SRC_HTML)
-      .on('change', () => generateMockHtml(argv))
+      .on('change', async () => {
+        await sleep(0)
+        generateMockHtml(argv)
+      })
       .on('error', console.error)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "am-mocktimes",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Let's ease mock creation / pattern management and increase break time.",
   "homepage": "https://github.com/ampcpmgp/am-mocktimes",
   "main": "src/mock.js",

--- a/src/app/parts/tree.tag
+++ b/src/app/parts/tree.tag
@@ -122,9 +122,14 @@ import './icons/open-close.tag'
     import * as Actions from '../../actions'
     import state from '../../state'
     import { getRoutePath } from '../../utils/pattern'
+    import {getTarget} from '../../utils/target'
 
     const openIframe = (e) => {
-      route(getRoutePath(opts.mdAction.mockUrl))
+      if (getTarget() === 'electron') {
+        location.assign(opts.mdAction.mockUrl)
+      } else {
+        route(getRoutePath(opts.mdAction.mockUrl))
+      }
       e.preventDefault()
     }
 

--- a/src/app/parts/tree.tag
+++ b/src/app/parts/tree.tag
@@ -122,14 +122,9 @@ import './icons/open-close.tag'
     import * as Actions from '../../actions'
     import state from '../../state'
     import { getRoutePath } from '../../utils/pattern'
-    import {getTarget} from '../../utils/target'
 
     const openIframe = (e) => {
-      if (getTarget() === 'electron') {
-        location.assign(opts.mdAction.mockUrl)
-      } else {
-        route(getRoutePath(opts.mdAction.mockUrl))
-      }
+      route(getRoutePath(opts.mdAction.mockUrl))
       e.preventDefault()
     }
 

--- a/src/app/parts/view-mock/index.tag
+++ b/src/app/parts/view-mock/index.tag
@@ -1,6 +1,11 @@
 <parts-view-mock>
   <iframe if="{opts.dataTarget === 'browser'}" src={opts.dataSrc}></iframe>
-  <webview if="{opts.dataTarget === 'electron'}" src={opts.dataSrc}></webview>
+  <webview
+    if="{opts.dataTarget === 'electron'}"
+    ref="webview" src={opts.dataSrc}
+    nodeintegration
+    >
+  </webview>
   <style type="less">
     :scope {
       position: fixed;
@@ -20,4 +25,12 @@
       height: inherit;
     }
   </style>
+
+  <script>
+    this.on('mount', () => {
+      this.refs.webview.addEventListener('dom-ready', () => {
+        this.refs.webview.openDevTools()
+      })
+    })
+  </script>
 </parts-view-mock>


### PR DESCRIPTION
electron/webviewの起動では、logがtext形式でしか取得できなく見づらい状況になっていたため、直接移動して確認する。